### PR TITLE
bump versions of libs due to CVEs

### DIFF
--- a/modules/xact/queue/activemq/application.xml
+++ b/modules/xact/queue/activemq/application.xml
@@ -16,7 +16,7 @@
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
-<Application applicationName="ActiveMQ" comment="" factoryVersion="" versionName="1.0.2" xmlVersion="1.1">
+<Application applicationName="ActiveMQ" comment="" factoryVersion="" versionName="1.0.3" xmlVersion="1.1">
   <ApplicationInfo>
     <Description Lang="DE">ActiveMQ</Description>
     <Description Lang="EN">ActiveMQ</Description>

--- a/modules/xact/queue/activemq/sharedlib/activemq/pom.xml
+++ b/modules/xact/queue/activemq/sharedlib/activemq/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
-            <version>5.13.1</version>
+            <version>5.14.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.13</version>
+            <version>1.7.26</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/modules/xact/ssh/server/application.xml
+++ b/modules/xact/ssh/server/application.xml
@@ -16,7 +16,7 @@
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
-<Application applicationName="SSHServer" comment="SSH Trigger und Filter" factoryVersion="" versionName="1.0.4" xmlVersion="1.1">
+<Application applicationName="SSHServer" comment="SSH Trigger und Filter" factoryVersion="" versionName="1.0.5" xmlVersion="1.1">
   <ApplicationInfo>
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>

--- a/modules/xact/ssh/server/sharedlib/SSHServer/pom.xml
+++ b/modules/xact/ssh/server/sharedlib/SSHServer/pom.xml
@@ -36,13 +36,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.3</version>
+            <version>2.17.1</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.16</version>
+            <version>1.7.26</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
both applications build with changed dependencies. Please verify runtime behaviour and merge.

Change SLF version to next version without vulnerabilty
Use the same version for log4j SLF binding as for log4j