### PR TITLE
86 update commons net package

### DIFF
--- a/modules/xact/connection/telnet/application.xml
+++ b/modules/xact/connection/telnet/application.xml
@@ -16,7 +16,7 @@
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
-<Application applicationName="Telnet" comment="" factoryVersion="" versionName="1.1.5" xmlVersion="1.1">
+<Application applicationName="Telnet" comment="" factoryVersion="" versionName="1.1.6" xmlVersion="1.1">
   <ApplicationInfo>
     <Description Lang="DE">Telnet Connection</Description>
     <Description Lang="EN">Telnet connection</Description>

--- a/modules/xact/connection/telnet/mdmimpl/TelnetConnectionImpl/pom.xml
+++ b/modules/xact/connection/telnet/mdmimpl/TelnetConnectionImpl/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>1.4.1</version>
+            <version>3.9.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -40,12 +40,6 @@
 				<scope>compile</scope>
       </dependency>
       <dependency>
-        <groupId>commons-net</groupId>
-				<artifactId>commons-net</artifactId>
-				<version>1.4.1</version>
-				<scope>compile</scope>
-      </dependency>
-      <dependency>
         <groupId>org.eclipse.jdt</groupId>
 				<artifactId>ecj</artifactId>
 				<version>I20181121gip</version>


### PR DESCRIPTION
Server doesn't seem to use the commons-net package at all -> I removed it from the dependencies.

xact/connections/telnet uses the TelnetClient and FtpClient classes from the commons-net package. I compared the documentations (1.4.1 docs: https://javadoc.io/doc/commons-net/commons-net/1.4.1/index.html, 3.9.0 docs: https://javadoc.io/doc/commons-net/commons-net/latest/index.html) and the methods and members that are used haven't changed.