### PR TITLE
added missing getters, fixed annotation, new version: 1.4.4

### DIFF
--- a/modules/xact/mail/application.xml
+++ b/modules/xact/mail/application.xml
@@ -16,7 +16,7 @@
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
-<Application applicationName="Mail" comment="" factoryVersion="" versionName="1.4.3" xmlVersion="1.1">
+<Application applicationName="Mail" comment="" factoryVersion="" versionName="1.4.4" xmlVersion="1.1">
   <ApplicationInfo>
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>

--- a/modules/xact/mail/sharedlib/MailAccounts/src/xact/mail/account/MailAccountPropertyStorable.java
+++ b/modules/xact/mail/sharedlib/MailAccounts/src/xact/mail/account/MailAccountPropertyStorable.java
@@ -57,7 +57,7 @@ public class MailAccountPropertyStorable extends Storable<MailAccountPropertySto
   private String key;
   @Column(name = COL_VALUE)
   private String value;
-  @Column(name = COL_VALUE, size = 2000)
+  @Column(name = COL_DOCUMENTATION, size = 2000)
   private String documentation;
   
   public MailAccountPropertyStorable() {
@@ -137,9 +137,23 @@ public class MailAccountPropertyStorable extends Storable<MailAccountPropertySto
       "select * from "+MailAccountPropertyStorable.TABLE_NAME
       +" where "+MailAccountPropertyStorable.COL_NAME+"=?";
 
+  public String getIndex() {
+    return namekeyIndex;
+  }
   public String getName() {
     return name;
   }
   
+  public String getKey() {
+    return key;
+  }
+
+  public String getValue() {
+    return value;
+  }
+  
+  public String getDocumentation() {
+    return documentation;
+  }
 
 }


### PR DESCRIPTION
- All members except for name were missing getters. This caused the expcetion mentioned in the bug. 
- The annotation for member documentation defined the wrong name (COL_VALUE instead of COL_DOCUMENTATION). 
- Increased version from 1.4.3 to 1.4.4.