### PR TITLE
add property to properly reference ant-xyna dir (#1)

### DIFF
--- a/installation/build/ant-xyna.xml
+++ b/installation/build/ant-xyna.xml
@@ -23,6 +23,8 @@
        Version: 2.3.2.0
    -->
 
+  <dirname property="ant.file.ant-xyna.dir" file="${ant.file.ant-xyna}" />
+
   <tstamp>
     <format property="timestamp" pattern="yyyyMMdd_HHmm" locale="de,DE" />
   </tstamp>
@@ -126,7 +128,7 @@
 
   <condition property="isInstall" value="true" else="false">
     <not>
-      <available file="${ant.file.ant-xyna}/../build.xml" />
+      <available file="${ant.file.ant-xyna.dir}/build.xml" />
     </not>
   </condition>
 
@@ -134,12 +136,12 @@
     <isset property="as.port.opmn" />
   </condition>
 
-  <property name="install.lib.dir" value="${ant.file.ant-xyna}/../lib" />
+  <property name="install.lib.dir" value="${ant.file.ant-xyna.dir}/lib" />
 
   <!-- remove filename/.. from path because sqlplus dont accepts it -->
   <pathconvert property="sql.dir">
     <path>
-      <dirset dir="${ant.file.ant-xyna}/..">
+      <dirset dir="${ant.file.ant-xyna.dir}">
         <include name="sql" />
       </dirset>
     </path>
@@ -205,10 +207,10 @@
   <if>
     <equals arg1="${isInstall}" arg2="true" />
     <then>
-      <property file="${ant.file.ant-xyna}/../patch.properties" />
+      <property file="${ant.file.ant-xyna.dir}/patch.properties" />
     </then>
     <else>
-      <property file="${ant.file.ant-xyna}/../../delivery/patch.properties" />
+      <property file="${ant.file.ant-xyna.dir}/../delivery/patch.properties" />
     </else>
   </if>
 
@@ -236,7 +238,7 @@
     </classpath>
   </taskdef>
 
-  <condition property="mavenSettingFile" value="${user.home}/mavenSettings.xml" else="${ant.file.ant-xyna}/../defaultMavenSettings.xml">
+  <condition property="mavenSettingFile" value="${user.home}/mavenSettings.xml" else="${ant.file.ant-xyna.dir}/defaultMavenSettings.xml">
     <available file="${user.home}/mavenSettings.xml" />
   </condition>
 
@@ -375,7 +377,7 @@
   <if>
     <equals arg1="${isInstall}" arg2="true" />
     <then>
-      <loadproperties srcfile="${ant.file.ant-xyna}/../install.properties" />
+      <loadproperties srcfile="${ant.file.ant-xyna.dir}/install.properties" />
 
       <exec executable="hostname" outputproperty="server.hostname" />
       <loadproperties srcfile="/etc/xyna/environment/${server.hostname}.properties" />
@@ -459,9 +461,9 @@
       </then>
       <else>
         <echo message="Start sequential update." />
-        <updateSequential update.dir="${ant.file.ant-xyna}/../update" />
+        <updateSequential update.dir="${ant.file.ant-xyna.dir}/update" />
         <echo message="Finished sequential update." />
-        <ant dir="${ant.file.ant-xyna}/../.."
+        <ant dir="${ant.file.ant-xyna.dir}/.."
              antfile="install.xml"
              target="install-ear" />
         <getVersion tag="db" result="db.version" />
@@ -472,12 +474,12 @@
                            already been updated to version ${db.version}." />
           </then>
           <else>
-            <ant dir="${ant.file.ant-xyna}/../.."
+            <ant dir="${ant.file.ant-xyna.dir}/.."
                  antfile="install.xml"
                  target="install-workflow" />
           </else>
         </if>
-        <ant dir="${ant.file.ant-xyna}/../.."
+        <ant dir="${ant.file.ant-xyna.dir}/.."
              antfile="install.xml"
              target="install-routing" />
       </else>

--- a/installation/build/ant-xyna.xml
+++ b/installation/build/ant-xyna.xml
@@ -23,8 +23,6 @@
        Version: 2.3.2.0
    -->
 
-  <dirname property="ant.file.ant-xyna.dir" file="${ant.file.ant-xyna}" />
-
   <tstamp>
     <format property="timestamp" pattern="yyyyMMdd_HHmm" locale="de,DE" />
   </tstamp>
@@ -128,7 +126,7 @@
 
   <condition property="isInstall" value="true" else="false">
     <not>
-      <available file="${ant.file.ant-xyna.dir}/build.xml" />
+      <available file="${ant.file.ant-xyna}/../build.xml" />
     </not>
   </condition>
 
@@ -136,12 +134,12 @@
     <isset property="as.port.opmn" />
   </condition>
 
-  <property name="install.lib.dir" value="${ant.file.ant-xyna.dir}/lib" />
+  <property name="install.lib.dir" value="${ant.file.ant-xyna}/../lib" />
 
   <!-- remove filename/.. from path because sqlplus dont accepts it -->
   <pathconvert property="sql.dir">
     <path>
-      <dirset dir="${ant.file.ant-xyna.dir}">
+      <dirset dir="${ant.file.ant-xyna}/..">
         <include name="sql" />
       </dirset>
     </path>
@@ -207,10 +205,10 @@
   <if>
     <equals arg1="${isInstall}" arg2="true" />
     <then>
-      <property file="${ant.file.ant-xyna.dir}/patch.properties" />
+      <property file="${ant.file.ant-xyna}/../patch.properties" />
     </then>
     <else>
-      <property file="${ant.file.ant-xyna.dir}/../delivery/patch.properties" />
+      <property file="${ant.file.ant-xyna}/../../delivery/patch.properties" />
     </else>
   </if>
 
@@ -238,7 +236,7 @@
     </classpath>
   </taskdef>
 
-  <condition property="mavenSettingFile" value="${user.home}/mavenSettings.xml" else="${ant.file.ant-xyna.dir}/defaultMavenSettings.xml">
+  <condition property="mavenSettingFile" value="${user.home}/mavenSettings.xml" else="${ant.file.ant-xyna}/../defaultMavenSettings.xml">
     <available file="${user.home}/mavenSettings.xml" />
   </condition>
 
@@ -377,7 +375,7 @@
   <if>
     <equals arg1="${isInstall}" arg2="true" />
     <then>
-      <loadproperties srcfile="${ant.file.ant-xyna.dir}/install.properties" />
+      <loadproperties srcfile="${ant.file.ant-xyna}/../install.properties" />
 
       <exec executable="hostname" outputproperty="server.hostname" />
       <loadproperties srcfile="/etc/xyna/environment/${server.hostname}.properties" />
@@ -461,9 +459,9 @@
       </then>
       <else>
         <echo message="Start sequential update." />
-        <updateSequential update.dir="${ant.file.ant-xyna.dir}/update" />
+        <updateSequential update.dir="${ant.file.ant-xyna}/../update" />
         <echo message="Finished sequential update." />
-        <ant dir="${ant.file.ant-xyna.dir}/.."
+        <ant dir="${ant.file.ant-xyna}/../.."
              antfile="install.xml"
              target="install-ear" />
         <getVersion tag="db" result="db.version" />
@@ -474,12 +472,12 @@
                            already been updated to version ${db.version}." />
           </then>
           <else>
-            <ant dir="${ant.file.ant-xyna.dir}/.."
+            <ant dir="${ant.file.ant-xyna}/../.."
                  antfile="install.xml"
                  target="install-workflow" />
           </else>
         </if>
-        <ant dir="${ant.file.ant-xyna.dir}/.."
+        <ant dir="${ant.file.ant-xyna}/../.."
              antfile="install.xml"
              target="install-routing" />
       </else>

--- a/installation/install.xml
+++ b/installation/install.xml
@@ -17,6 +17,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
 <project default="help" basedir="." xmlns:oracle="antlib:oracle">
+	<property name="ant.xyna.dir" value="${basedir}/build" />
 
 	<import file="install/install.xml" />
 	

--- a/installation/install/install.xml
+++ b/installation/install/install.xml
@@ -17,8 +17,8 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
 <project name="install" default="help" basedir="." xmlns:oracle="antlib:oracle">
-  
-  <import file="ant-xyna.xml" />
+  <property name="ant.xyna.dir" value="${basedir}/../build" />
+  <import file="${ant.xyna.dir}/ant-xyna.xml" />
 
   <start_logging name="${delivery.name}" />
 


### PR DESCRIPTION
ant-xyna.xml is now properly referenced.

However, when `ant -f installation/install.xml` is called now, the line https://github.com/GIP-SmartMercial/xyna-factory/blob/8743d6e8f89d6a6f73320b35331dc4558f802642/installation/install/install.xml#L23 can't execute because `delivery.name` is never read.