### PR TITLE
118 fix log4j dependabot alerts

### DIFF
--- a/xynautils/database/pom.xml
+++ b/xynautils/database/pom.xml
@@ -43,7 +43,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
             <version>2.17.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>

--- a/xynautils/database/pom.xml
+++ b/xynautils/database/pom.xml
@@ -30,24 +30,20 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.15</version>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.jmx</groupId>
-                    <artifactId>jmxri</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jdmk</groupId>
-                    <artifactId>jmxtools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>jms</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.17.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.jdbc</groupId>

--- a/xynautils/database/pom.xml
+++ b/xynautils/database/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gip.xyna</groupId>
     <artifactId>xynautils-database</artifactId>
-    <version>2.15.0.0</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/xynautils/exceptions/pom.xml
+++ b/xynautils/exceptions/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gip.xyna</groupId>
     <artifactId>xynautils-exceptions</artifactId>
-    <version>3.3.0.1</version>
+    <version>4.0.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/xynautils/exceptions/pom.xml
+++ b/xynautils/exceptions/pom.xml
@@ -43,7 +43,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
             <version>2.17.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/xynautils/exceptions/pom.xml
+++ b/xynautils/exceptions/pom.xml
@@ -30,24 +30,20 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.15</version>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.jmx</groupId>
-                    <artifactId>jmxri</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jdmk</groupId>
-                    <artifactId>jmxtools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>jms</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.17.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/xynautils/logging/pom.xml
+++ b/xynautils/logging/pom.xml
@@ -43,7 +43,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
             <version>2.17.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/xynautils/logging/pom.xml
+++ b/xynautils/logging/pom.xml
@@ -32,17 +32,17 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.8.1</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.8.1</version>
+            <version>2.17.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
-            <version>2.8.1</version>
+            <version>2.17.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/xynautils/logging/src/com/gip/xyna/utils/logging/syslog/SysLogger.java
+++ b/xynautils/logging/src/com/gip/xyna/utils/logging/syslog/SysLogger.java
@@ -24,7 +24,7 @@ import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
-import org.apache.logging.log4j.util.ReflectionUtil;
+import org.apache.logging.log4j.util.StackLocator;
 
 
 /**
@@ -455,11 +455,12 @@ public class SysLogger extends Logger {
 
    private String getCallerClassName() {
       int stackPosition = 2;
-      String caller = ReflectionUtil.getCallerClass(stackPosition).getName();
+      StackLocator locator = StackLocator.getInstance();
+      String caller = locator.getCallerClass(stackPosition).getName();
       // TODO: check against all subclasses of Logger
       while (caller.equals(this.getClass().getName())
             || caller.equals("java.util.logging.Logger")) {
-         caller = ReflectionUtil.getCallerClass(++stackPosition).getName();
+         caller = locator.getCallerClass(++stackPosition).getName();
       }
       return caller;
    }

--- a/xynautils/misc/pom.xml
+++ b/xynautils/misc/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gip.xyna</groupId>
     <artifactId>xynautils-misc</artifactId>
-    <version>2.3.0.0</version>
+    <version>3.0.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/xynautils/misc/pom.xml
+++ b/xynautils/misc/pom.xml
@@ -30,23 +30,20 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.15</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.jmx</groupId>
-                    <artifactId>jmxri</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jdmk</groupId>
-                    <artifactId>jmxtools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>jms</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.17.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.xml</groupId>

--- a/xynautils/misc/pom.xml
+++ b/xynautils/misc/pom.xml
@@ -43,7 +43,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
             <version>2.17.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.oracle.database.xml</groupId>

--- a/xynautils/snmp/pom.xml
+++ b/xynautils/snmp/pom.xml
@@ -43,7 +43,6 @@
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-1.2-api</artifactId>
             <version>2.17.1</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.snmp4j</groupId>

--- a/xynautils/snmp/pom.xml
+++ b/xynautils/snmp/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gip.xyna</groupId>
     <artifactId>xynautils-snmp</artifactId>
-    <version>3.0.1.1</version>
+    <version>4.0.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/xynautils/snmp/pom.xml
+++ b/xynautils/snmp/pom.xml
@@ -30,24 +30,20 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>1.2.15</version>
-            <scope>runtime</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.sun.jmx</groupId>
-                    <artifactId>jmxri</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.sun.jdmk</groupId>
-                    <artifactId>jmxtools</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>javax.jms</groupId>
-                    <artifactId>jms</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.17.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+            <version>2.17.1</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.snmp4j</groupId>


### PR DESCRIPTION
Updating was straight forwards for most xynautils.

Had exchange on Class (ReflectionUtil) in SysLogger.java because ReflectionUtil isn't supported since log4j-api v 2.9.0.

Updated Version numbers for each changed xynautil