### PR TITLE
132 fix missing licenses in lib directory

### DIFF
--- a/clusterproviders/OracleRACClusterProvider/build.xml
+++ b/clusterproviders/OracleRACClusterProvider/build.xml
@@ -57,7 +57,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/clusterproviders/XSORClusterProvider/build.xml
+++ b/clusterproviders/XSORClusterProvider/build.xml
@@ -98,7 +98,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/components/xact/NetworkAvailability/build.xml
+++ b/components/xact/NetworkAvailability/build.xml
@@ -53,7 +53,7 @@
       <resolver:remoterepos refid="xyna.repository"/>
       <resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/>
     </resolver:resolve>
-    <!--loadLicenses targetDir="${target.dir}/lib" /-->
+    <loadLicenses targetDir="${target.dir}/lib" />
     <!-- delete generated-resources ? -->
   </target>
 

--- a/components/xnwh/pools/DefaultConnectionPoolTypes/build.xml
+++ b/components/xnwh/pools/DefaultConnectionPoolTypes/build.xml
@@ -48,7 +48,7 @@
 	  <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
 	  <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-	<!--loadLicenses targetDir="${basedir}/lib" /-->
+		<loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 	<!--path id="libraries">

--- a/installation/build/copyLicenseFiles.sh
+++ b/installation/build/copyLicenseFiles.sh
@@ -16,14 +16,8 @@
 # limitations under the License.
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-#copy license files in input dir to output dir
-#copy alle entries of GROUP-file
+#copy license files (non .jar-files) in input dir to output dir
 
 mkdir "$2"
-for i in $(find "$1" -name "*GROUP*" | grep -v "jar\$" | xargs grep -v "^#"); do cp "$1/$i" "$2"; done
-for i in $(find "$1" -iname "*LICENSE*" | grep -v "jar\$"); do cp "$i" "$2"; done
-for i in $(find "$1" -iname "*LICENCE*" | grep -v "jar\$"); do cp "$i" "$2"; done
-for i in $(find "$1" -iname "*NOTICE*" | grep -v "jar\$"); do cp "$i" "$2"; done
-for i in $(find "$1" -name "*GROUP*" | grep -v "jar\$"); do cp "$i" "$2"; done
-for i in $(find "$1" -iname "*COPYRIGHT*" | grep -v "jar\$"); do cp "$i" "$2"; done
+while read -r i; do cp "$i" "$2"; done <<< $(find "$1" ! -iname "*.jar" -type f)
 

--- a/misc/build.xml
+++ b/misc/build.xml
@@ -48,7 +48,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/orderinputsources/ConstantInputSource/build.xml
+++ b/orderinputsources/ConstantInputSource/build.xml
@@ -55,7 +55,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/orderinputsources/WorkflowInputSource/build.xml
+++ b/orderinputsources/WorkflowInputSource/build.xml
@@ -55,7 +55,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 	  	

--- a/persistencelayers/MySQLPersistenceLayer/build.xml
+++ b/persistencelayers/MySQLPersistenceLayer/build.xml
@@ -49,7 +49,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/persistencelayers/OraclePersistenceLayer/build.xml
+++ b/persistencelayers/OraclePersistenceLayer/build.xml
@@ -48,7 +48,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/persistencelayers/XynaDevNullPersistenceLayer/build.xml
+++ b/persistencelayers/XynaDevNullPersistenceLayer/build.xml
@@ -46,7 +46,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/persistencelayers/XynaJavaSerializationPersistenceLayer/build.xml
+++ b/persistencelayers/XynaJavaSerializationPersistenceLayer/build.xml
@@ -47,7 +47,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/persistencelayers/XynaLocalMemoryPersistenceLayer/build.xml
+++ b/persistencelayers/XynaLocalMemoryPersistenceLayer/build.xml
@@ -58,7 +58,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/persistencelayers/XynaMemoryPersistenceLayer/build.xml
+++ b/persistencelayers/XynaMemoryPersistenceLayer/build.xml
@@ -91,7 +91,7 @@
           <resolver:files refid="files" dir="${basedir}/lib.test" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="test"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/persistencelayers/XynaXMLShellPersistenceLayer/build.xml
+++ b/persistencelayers/XynaXMLShellPersistenceLayer/build.xml
@@ -47,7 +47,7 @@
           <resolver:files refid="files" dir="${basedir}/lib/xyna" layout="{artifactId}-{classifier}-{version}.{extension}"/>
           <!--resolver:files refid="files" dir="${basedir}/lib" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/-->
         </resolver:resolve>
-        <!--loadLicenses targetDir="${basedir}/lib" /-->
+        <loadLicenses targetDir="${basedir}/lib" />
         <!-- delete generated-resources ? -->
       </target>
 

--- a/server/build.xml
+++ b/server/build.xml
@@ -44,7 +44,7 @@
       <resolver:files refid="files" dir="${target.dir}" layout="{artifactId}-{classifier}-{version}.{extension}" /> <!--scopes="compile"-->
       <resolver:files refid="internalFiles" dir="${target.dir}/internal_xyna" layout="{artifactId}-{classifier}-{version}.{extension}" scopes="runtime"/>
     </resolver:resolve>
-    <!--loadLicenses targetDir="${target.dir}" /-->
+    <loadLicenses targetDir="${target.dir}" />
     <!-- delete generated-resources ? -->
   </target>
 


### PR DESCRIPTION
Un-uncommented a lot of `loadLicenses`-calls in `resolve`-targets.

Also fixed the `copyLicenseFiles.sh` since it had issues with filenames containing spaces