### PR TITLE
removefactorynode

### DIFF
--- a/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/NodeManagement.java
+++ b/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/NodeManagement.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 GIP SmartMercial GmbH, Germany
+ * Copyright 2023 GIP SmartMercial GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/NodeManagement.java
+++ b/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/NodeManagement.java
@@ -468,8 +468,8 @@ public class NodeManagement extends FunctionGroup {
     return fnc;
   }
 
-  public void removeFactoryNodeCaller(String nodeName) {
-    factoryNodeCaller.remove(nodeName);
+  public FactoryNodeCaller removeFactoryNodeCaller(String nodeName) {
+    return factoryNodeCaller.remove(nodeName);
   }
 
 }

--- a/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/FactoryNodeCaller.java
+++ b/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/FactoryNodeCaller.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 GIP SmartMercial GmbH, Germany
+ * Copyright 2023 GIP SmartMercial GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/FactoryNodeCaller.java
+++ b/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/FactoryNodeCaller.java
@@ -28,6 +28,7 @@ import com.gip.xyna.CentralFactoryLogging;
 import com.gip.xyna.XynaFactory;
 import com.gip.xyna.xfmg.xfctrl.nodemgmt.FactoryNode;
 import com.gip.xyna.xfmg.xfctrl.nodemgmt.NodeManagement;
+import com.gip.xyna.xfmg.xfctrl.nodemgmt.remotecall.NotificationProcessor.RemoteCallNotificationStatus;
 import com.gip.xyna.xfmg.xfctrl.nodemgmt.remotecall.Resumer.ResumeData;
 import com.gip.xyna.xfmg.xfctrl.nodemgmt.remotecall.notifications.AwaitOrderNotification;
 import com.gip.xyna.xfmg.xfctrl.nodemgmt.remotecall.notifications.RemoteCallNotification;
@@ -119,6 +120,10 @@ public class FactoryNodeCaller {
   }
   
   public void shutdown() {
+    shutdown(true);
+  }
+  
+  public void shutdown(boolean hasSuccessor) {
     NodeManagement nm = XynaFactory.getInstance().getFactoryManagement().getXynaFactoryControl().getNodeManagement();
     
     //Threads beenden
@@ -135,13 +140,20 @@ public class FactoryNodeCaller {
     if( ! notificationProcessor.isFinished() ) {
       //nun sind doch nochmal unerwartet Aufträge eingegangen ...
       //diese nun umtragen in aktuellen FactoryNodeCaller
-      FactoryNodeCaller successor = nm.getFactoryNodeCaller(nodeName);
-      for( RemoteCallNotification n : notificationProcessor.getNotifications())
-      successor.enqueue(n);
+      if(hasSuccessor) {
+        FactoryNodeCaller successor = nm.getFactoryNodeCaller(nodeName);
+        for( RemoteCallNotification n : notificationProcessor.getNotifications()) {
+          successor.enqueue(n);
+        }
+      } else {
+        for( RemoteCallNotification n : notificationProcessor.getNotifications()) {
+          n.setStatusAndNotify(RemoteCallNotificationStatus.Removed);
+        }
+      }
     }
     
     //Sind noch Responses eingegangen?
-    if( ! responses.isEmpty() ) {
+    if( ! responses.isEmpty() && hasSuccessor) {
       //nun sind doch nochmal unerwartet Aufträge eingegangen ...
       //diese nun umtragen in aktuellen FactoryNodeCaller
       FactoryNodeCaller successor = nm.getFactoryNodeCaller(nodeName);
@@ -151,8 +163,14 @@ public class FactoryNodeCaller {
     if( ! awaitResponses.isEmpty() ) {
       //nun sind doch nochmal unerwartet Aufträge eingegangen ...
       //diese nun umtragen in aktuellen FactoryNodeCaller
-      FactoryNodeCaller successor = nm.getFactoryNodeCaller(nodeName);
-      successor.awaitResponses.putAll(awaitResponses);
+      if(hasSuccessor) {
+        FactoryNodeCaller successor = nm.getFactoryNodeCaller(nodeName);
+        successor.awaitResponses.putAll(awaitResponses);
+      } else {
+        for(AwaitOrderNotification awaitResponse : awaitResponses.values()) {
+          awaitResponse.abort(nodeName);
+        }
+      }
     }
     
   }

--- a/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/RemoteCallHelper.java
+++ b/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/RemoteCallHelper.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 GIP SmartMercial GmbH, Germany
+ * Copyright 2023 GIP SmartMercial GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/RemoteCallHelper.java
+++ b/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/RemoteCallHelper.java
@@ -60,7 +60,6 @@ import com.gip.xyna.xprc.xpce.ordersuspension.ResumeTarget;
 import com.gip.xyna.xprc.xpce.ordersuspension.SuspensionBackupMode;
 import com.gip.xyna.xprc.xpce.ordersuspension.suspensioncauses.SuspensionCause_ShutDown;
 import com.gip.xyna.xprc.xpce.ordersuspension.suspensioncauses.SuspensionCause_Standard;
-import com.gip.xyna.xprc.xpce.parameterinheritance.ParameterInheritanceManagement.ParameterType;
 import com.gip.xyna.xprc.xpce.parameterinheritance.rules.InheritanceRule;
 import com.gip.xyna.xprc.xprcods.orderarchive.OrderInstanceBackup.BackupCause;
 
@@ -268,6 +267,10 @@ public class RemoteCallHelper {
     } else if( suspend && awaitOrder.isParked() ) {
       logger.debug("RCH: awaitOrder -> suspend "+correlatedXynaOrder.getId()  +  " System time: " + System.currentTimeMillis());
       throw new ProcessSuspendedException( new SuspensionCause_Standard() );
+    } else if( awaitOrder.isAborted()) {
+      //order was aborted because remote node was removed. 
+      //Exception is always set if aborted is true
+      throw awaitOrder.getNodeConnectException();
     } else if( awaitOrder.getNodeConnectException() != null ) {
       if (logger.isDebugEnabled()) {
         logger.debug("RCH: could not connect to node: " + awaitOrder.getNodeConnectException().getMessage());

--- a/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/notifications/AwaitOrderNotification.java
+++ b/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/notifications/AwaitOrderNotification.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 GIP SmartMercial GmbH, Germany
+ * Copyright 2023 GIP SmartMercial GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/notifications/AwaitOrderNotification.java
+++ b/server/src/com/gip/xyna/xfmg/xfctrl/nodemgmt/remotecall/notifications/AwaitOrderNotification.java
@@ -33,6 +33,7 @@ public class AwaitOrderNotification extends RemoteCallNotification {
   
   private long absoluteTimeout;
   private ResumeTarget resumeTarget;
+  private boolean aborted;
 
   public AwaitOrderNotification(Long remoteOrderId) {
     setOrderId(remoteOrderId);
@@ -52,6 +53,9 @@ public class AwaitOrderNotification extends RemoteCallNotification {
     return resumeTarget;
   }
 
+  public boolean isAborted() {
+    return aborted;
+  }
 
   @Override
   public RemoteCallNotificationStatus execute(FactoryNodeCaller factoryNodeCaller) {
@@ -79,6 +83,12 @@ public class AwaitOrderNotification extends RemoteCallNotification {
   }
 
   public void disconnect(String nodeName) {
+    setNodeConnectException( new XFMG_NodeConnectException(nodeName) );
+    setStatusAndNotify(RemoteCallNotificationStatus.Failed);
+  }
+  
+  public void abort(String nodeName) {
+    aborted = true;
     setNodeConnectException( new XFMG_NodeConnectException(nodeName) );
     setStatusAndNotify(RemoteCallNotificationStatus.Failed);
   }

--- a/server/src/com/gip/xyna/xmcp/xfcli/impl/RemovefactorynodeImpl.java
+++ b/server/src/com/gip/xyna/xmcp/xfcli/impl/RemovefactorynodeImpl.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 GIP SmartMercial GmbH, Germany
+ * Copyright 2023 GIP SmartMercial GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/src/com/gip/xyna/xmcp/xfcli/impl/RemovefactorynodeImpl.java
+++ b/server/src/com/gip/xyna/xmcp/xfcli/impl/RemovefactorynodeImpl.java
@@ -17,8 +17,12 @@
  */
 package com.gip.xyna.xmcp.xfcli.impl;
 
+
+
 import com.gip.xyna.XynaFactory;
+import com.gip.xyna.xfmg.exceptions.XFMG_NodeConnectException;
 import com.gip.xyna.xfmg.xfctrl.nodemgmt.NodeManagement;
+import com.gip.xyna.xfmg.xfctrl.nodemgmt.remotecall.FactoryNodeCaller;
 import com.gip.xyna.xmcp.xfcli.XynaCommandImplementation;
 import java.io.OutputStream;
 import com.gip.xyna.utils.exceptions.XynaException;
@@ -31,6 +35,16 @@ public class RemovefactorynodeImpl extends XynaCommandImplementation<Removefacto
   public void execute(OutputStream statusOutputStream, Removefactorynode payload) throws XynaException {
     NodeManagement nodeMgmt = XynaFactory.getInstance().getFactoryManagement().getXynaFactoryControl().getNodeManagement();
     nodeMgmt.removeNode(payload.getName());
+    FactoryNodeCaller caller = nodeMgmt.removeFactoryNodeCaller(payload.getName());
+
+    if (caller != null) {
+      try {
+        caller.getRemoteOrderExecution().abortCommunication();
+      } catch (XFMG_NodeConnectException e) {
+        writeToCommandLine(statusOutputStream, "Exception during shutdown of communication with " + payload.getName() + ". " + e.getMessage());
+      }
+      caller.shutdown(false);
+    }
   }
 
 }


### PR DESCRIPTION
configure a factorynode A (./xynafactory.sh addfactorynode)
run remote workflow
deconfigure factorynode A (./xynafactory.sh removefactorynode)
conifgure factorynode B (different target)
run remote workflow again.

Now, the correct factorynode (B) is called instead of A.