### PR TITLE
update workflow, add script

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -35,8 +35,14 @@ jobs:
     steps:
     - name: Check out the code
       uses: actions/checkout@v3
+    - name: Prepare central POM
+      run: sed -i '/\<\/\?dependencyManagement\>/d' ./installation/build/pom.xml
+    - name: Prune POMs
+      run: |
+        cd installation/build
+        ./cleanupPoms.py
     - name: Run the Anchore Grype scan action
-      uses: anchore/scan-action@v3.3.0
+      uses: anchore/scan-action@v3
       id: scan
       with:
         path: "."

--- a/installation/build/cleanupPoms.py
+++ b/installation/build/cleanupPoms.py
@@ -7,7 +7,6 @@ import io
 import os
 import re
 import glob
-import multiprocessing
 
 CENTRAL_POM_PATH = os.path.normpath("../../installation/build/pom.xml")
 

--- a/installation/build/cleanupPoms.py
+++ b/installation/build/cleanupPoms.py
@@ -11,38 +11,38 @@ import glob
 CENTRAL_POM_PATH = os.path.normpath("../../installation/build/pom.xml")
 
 
-def removeInheritedDependencies(pom: io.TextIOWrapper) -> str:
+def remove_inherited_dependencies(pom: io.TextIOWrapper) -> str:
     """
     Goes through the contents and removes each <dependency> tag that doesn't specify a version.
 
     Updates the content of the file.
 
     We find all <dependency> tags with a regexp, then we go through each match 
-    and write from the last valid index to the start of the match. The last valid index is then set to the end of the match
+    and write from the last valid index to the start of the match. 
+    The last valid index is then set to the end of the match
     """
     content = pom.read()
     pom.seek(0)
-    lastIndex = 0
+    last_index = 0
     for match in re.finditer(r'<dependency>.*?</dependency>', content, re.DOTALL):
         # skip matches that have a version specified
         if "<version>" in content[match.start():match.end()]:
             continue
-        pom.write(content[lastIndex:match.start()])
-        lastIndex = match.end()
-    pom.write(content[lastIndex:])
+        pom.write(content[last_index:match.start()])
+        last_index = match.end()
+    pom.write(content[last_index:])
     pom.truncate()
 
 
 def main():
-    pomPaths = [os.path.normpath(path) for path in glob.glob("../../**/pom.xml", recursive=True)]
-    for pomXml in pomPaths:
+    pom_paths = [os.path.normpath(path) for path in glob.glob("../../**/pom.xml", recursive=True)]
+    for pom_xml in pom_paths:
         # ignore central pom.xml
-        if os.path.samefile(pomXml, CENTRAL_POM_PATH):
-            print(f"Skip {pomXml}")
+        if os.path.samefile(pom_xml, CENTRAL_POM_PATH):
             continue
 
-        with open(pomXml, "r+") as pomFile:
-            removeInheritedDependencies(pomFile)
+        with open(pom_xml, "r+") as pom_file:
+            remove_inherited_dependencies(pom_file)
 
 
 if __name__ == "__main__":

--- a/installation/build/cleanupPoms.py
+++ b/installation/build/cleanupPoms.py
@@ -11,7 +11,7 @@ import glob
 CENTRAL_POM_PATH = os.path.normpath("../../installation/build/pom.xml")
 
 
-def remove_inherited_dependencies(pom: io.TextIOWrapper) -> str:
+def remove_inherited_dependencies(pom: io.TextIOWrapper):
     """
     Goes through the contents and removes each <dependency> tag that doesn't specify a version.
 

--- a/installation/build/cleanupPoms.py
+++ b/installation/build/cleanupPoms.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+"""
+Goes through all the pom.xml files and removes all <dependency> tags without a version specified
+"""
+
+import io
+import os
+import re
+import glob
+import multiprocessing
+
+CENTRAL_POM_PATH = os.path.normpath("../../installation/build/pom.xml")
+
+
+def removeInheritedDependencies(pom: io.TextIOWrapper) -> str:
+    """
+    Goes through the contents and removes each <dependency> tag that doesn't specify a version.
+
+    Updates the content of the file.
+
+    We find all <dependency> tags with a regexp, then we go through each match 
+    and write from the last valid index to the start of the match. The last valid index is then set to the end of the match
+    """
+    content = pom.read()
+    pom.seek(0)
+    lastIndex = 0
+    for match in re.finditer(r'<dependency>.*?</dependency>', content, re.DOTALL):
+        # skip matches that have a version specified
+        if "<version>" in content[match.start():match.end()]:
+            continue
+        pom.write(content[lastIndex:match.start()])
+        lastIndex = match.end()
+    pom.write(content[lastIndex:])
+    pom.truncate()
+
+
+def main():
+    pomPaths = [os.path.normpath(path) for path in glob.glob("../../**/pom.xml", recursive=True)]
+    for pomXml in pomPaths:
+        # ignore central pom.xml
+        if os.path.samefile(pomXml, CENTRAL_POM_PATH):
+            print(f"Skip {pomXml}")
+            continue
+
+        with open(pomXml, "r+") as pomFile:
+            removeInheritedDependencies(pomFile)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- workflow will use a newer version of the scan-action --> new vulnerabilities have been found
- to properly scan the dependencies specified in the [central pom](installation/build/pom.xml) the `dependencyManacement` tags are removed by an `sed` call
- to not get confused by dependencies that inherit their version, a [python script](installation/build/cleanupPoms.py) goes through each `pom.xml` (except for the central `pom.xml`) and removes every `dependency` tag that doesn't include a `version` tag --> POMs with costum dependency versions are still properly scanned