### PR TITLE
remove explicit version

### DIFF
--- a/components/xact/sftp/triggerimpl/SFTPTrigger/pom.xml
+++ b/components/xact/sftp/triggerimpl/SFTPTrigger/pom.xml
@@ -219,7 +219,6 @@
         <dependency>
             <groupId>com.gip.xyna</groupId>
             <artifactId>xynautils-exceptions</artifactId>
-            <version>I20210705_1332</version>
         </dependency>
     </dependencies>
 </project>

--- a/xynautils/misc/pom.xml
+++ b/xynautils/misc/pom.xml
@@ -64,7 +64,6 @@
         <dependency>
             <groupId>com.gip.xyna</groupId>
             <artifactId>xynautils-exceptions</artifactId>
-            <version>3.0.0.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
validated using:
`ant resolve` and `ant integration` in xynautils/misc,
`ant build` in components/xact/sftp/triggerimpl/SFTPTrigger