### PR TITLE
shorten ids longer than 250 chars because github can't handle them

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -40,6 +40,7 @@ jobs:
               --sarif --output report.sarif \
               --metrics=off --disable-version-check --no-rewrite-rule-ids \
               -f semgrep-main-rules/rules
+            sed -ri 's/"(ruleId|id|name)": "([^"]{250})[^"]+"/"\1": "\2..."/' report.sarif
 
         # step 3
         - name: save report as pipeline artifact


### PR DESCRIPTION
2023-05-07T13:51:38.4942934Z ##[error]Code Scanning could not process the submitted SARIF file: could not convert rules: sarif identifier exceeds maximum length of 255 characters 2023-05-07T13:51:38.4953054Z Error: Code Scanning could not process the submitted SARIF file: 2023-05-07T13:51:38.4954392Z could not convert rules: sarif identifier exceeds maximum length of 255 characters
2023-05-07T13:51:38.4955152Z     at Object.waitForProcessing (/__w/_actions/github/codeql-action/v2/lib/upload-lib.js:330:23)
2023-05-07T13:51:38.4955690Z     at async run (/__w/_actions/github/codeql-action/v2/lib/upload-sarif-action.js:55:13)
2023-05-07T13:51:38.4956235Z     at async runWrapper (/__w/_actions/github/codeql-action/v2/lib/upload-sarif-action.js:70:9)